### PR TITLE
Create SupportService with TextViewSupportService

### DIFF
--- a/HoneyComb.Platform.Android/OS/Support/SupportService.cs
+++ b/HoneyComb.Platform.Android/OS/Support/SupportService.cs
@@ -1,0 +1,18 @@
+﻿using Android.Widget;
+
+namespace HoneyComb.Platform.Android.OS.Support
+{
+    /// <summary>
+    /// It provides flags that determine if an Android component feature
+    /// is supported by the current device Android OS version.
+    /// </summary>
+    public static class SupportService
+    {
+        /// <summary>
+        /// Gets SupportService for TextView.
+        /// </summary>
+        /// <param name="textView">TextView instance.</param>
+        /// <returns></returns>
+        public static TextViewSupportService GetSupport(TextView textView) => TextViewSupportService.Singleton;
+    }
+}

--- a/HoneyComb.Platform.Android/OS/Support/TextViewSupportService.cs
+++ b/HoneyComb.Platform.Android/OS/Support/TextViewSupportService.cs
@@ -1,0 +1,31 @@
+﻿using Android.Widget;
+
+namespace HoneyComb.Platform.Android.OS.Support
+{
+    /// <summary>
+    /// It provides flags that determine if an TextView feature
+    /// is supported by the current device Android OS version.
+    /// </summary>
+    public class TextViewSupportService
+    {
+        internal static TextViewSupportService Singleton = new TextViewSupportService();
+
+        private TextViewSupportService()
+        {
+        }
+
+        /// <summary>
+        /// Gets if <see cref="TextView.CompoundDrawableTintList"/> setter is supported.
+        /// </summary>
+        /// <param name="textView">TextView instance</param>
+        /// <returns>True if is supported, false otherwise</returns>
+        public bool IsCompoundDrawableTintListSetterSupported(TextView textView) => BuildVersionService.IsAtLeastApi23();
+
+        /// <summary>
+        /// Gets if <see cref="TextView.CompoundDrawableTintList"/> setter is unsupported.
+        /// </summary>
+        /// <param name="textView">TextView instance</param>
+        /// <returns>True if is unsupported, false otherwise</returns>
+        public bool IsCompoundDrawableTintListSetterUnsupported(TextView textView) => BuildVersionService.IsBelowApi23();
+    }
+}

--- a/HoneyComb.Platform.Android/Widget/TextView+SetCompoundDrawableTintList.cs
+++ b/HoneyComb.Platform.Android/Widget/TextView+SetCompoundDrawableTintList.cs
@@ -3,6 +3,7 @@ using Android.Widget;
 using HoneyComb.Platform.Android.Content.Res;
 using HoneyComb.Platform.Android.Core.Graphics.Drawables;
 using HoneyComb.Platform.Android.OS;
+using HoneyComb.Platform.Android.OS.Support;
 
 namespace HoneyComb.Platform.Android.Widget
 {
@@ -16,7 +17,7 @@ namespace HoneyComb.Platform.Android.Widget
         public static void SetCompoundDrawableTintList(this TextView @this, int colorResourceId)
         {
             var color = ColorService.GetColorStateList(@this.Context, colorResourceId);
-            if (BuildVersionService.IsBelowApi23())
+            if (SupportService.GetSupport(@this).IsCompoundDrawableTintListSetterUnsupported(@this))
             {
                 @this.SetCompoundDrawableTintListForApisBelow23(color);
                 return;


### PR DESCRIPTION
# Create SupportService with TextViewSupportService

It provides flags that determine if a TextView feature is supported by the current device Android OS version.